### PR TITLE
Added the ability to show/hide the rant content to the audience

### DIFF
--- a/public/settings.json
+++ b/public/settings.json
@@ -2,6 +2,7 @@
 	"performanceId": "hello-world",
 	"modPassword": "butts",
 	"title": "Hello World",
+	"showRantContentToAudience": true,
 	"callers": [ "Apple", "Banana" ],
 	"videoCallEmbedLink": "https://www.youtube.com/embed/jlyYqZqBDRw?si=sEtyIoaQfeWz5AOr",
 	"styles": {

--- a/src/App.css
+++ b/src/App.css
@@ -250,6 +250,7 @@ iframe#webpack-dev-server-client-overlay {
 }
 
 
+
 .submitted-text{
 	animation: bounce 1s forwards; 
 }

--- a/src/App.css
+++ b/src/App.css
@@ -249,8 +249,6 @@ iframe#webpack-dev-server-client-overlay {
 	display:none!important;
 }
 
-
-
 .submitted-text{
 	animation: bounce 1s forwards; 
 }

--- a/src/App.css
+++ b/src/App.css
@@ -248,3 +248,28 @@
 iframe#webpack-dev-server-client-overlay {
 	display:none!important;
 }
+
+
+.submitted-text{
+	animation: bounce 1s forwards; 
+}
+
+@keyframes bounce {
+  0% {
+	opacity: 0;
+    transform: translateY(0); 
+  }
+  15% {
+	opacity: 1;
+    transform: translateY(-25%); 
+  }
+  30% {
+    transform: translateY(0); 
+  }
+  50% {
+	opacity: 1;
+  }
+  100% {
+	opacity: 0;
+  }
+}

--- a/src/Audience.js
+++ b/src/Audience.js
@@ -87,12 +87,12 @@ class Audience extends React.Component {
 			} else {
 				let rantContent = null;
 				if(this.props.settings.showRantContentToAudience){
-				let r = null;
-				if (this.props.performance.rants) {
-					r = Object.keys(this.props.performance.rants).map((i) =>
-						<li key={i}>{this.props.performance.rants[i]}</li>
-					);
-				}
+					let r = null;
+					if (this.props.performance.rants) {
+						r = Object.keys(this.props.performance.rants).map((i) =>
+							<li key={i}>{this.props.performance.rants[i]}</li>
+						);
+					}
 					rantContent = <><p aria-hidden="true">Current rant content</p><ul aria-hidden="true">{r}</ul></>
 				}
 				return (

--- a/src/Audience.js
+++ b/src/Audience.js
@@ -85,11 +85,15 @@ class Audience extends React.Component {
 					</div>
 				);
 			} else {
+				let rantContent = null;
+				if(this.props.settings.showRantContentToAudience){
 				let r = null;
 				if (this.props.performance.rants) {
 					r = Object.keys(this.props.performance.rants).map((i) =>
 						<li key={i}>{this.props.performance.rants[i]}</li>
 					);
+				}
+					rantContent = <><p aria-hidden="true">Current rant content</p><ul aria-hidden="true">{r}</ul></>
 				}
 				return (
 					<div>
@@ -97,8 +101,8 @@ class Audience extends React.Component {
 							<p tabIndex="0" role="alert" >{newText.trim()}</p>
 							<TextBox onSubmitted={this.handleFreeResponse}/>
 						</div>
-						<p aria-hidden="true">Current rant content</p>
-						<ul aria-hidden="true">{r}</ul>
+						
+						{rantContent}
 					</div>
 				);
 			}

--- a/src/Common.js
+++ b/src/Common.js
@@ -23,15 +23,22 @@ export class TextBox extends React.Component {
   }
   handleSubmit(event) {
 	this.props.onSubmitted(this.state.value);
-	this.setState({value: ''});
+	this.setState({value: '',  submitted: true});
     event.preventDefault();
+	
+    setTimeout(() => {
+      this.setState({ submitted: false });
+    }, 1000);
   }
 	render() {
 		return (
+			<>
 			<form onSubmit={this.handleSubmit}>
 				<input type="text" value={this.state.value} onChange={this.handleChange} />
-                <input type="submit" value="Submit" />
+					<input disabled={this.state.value.length===0} type="submit" value="Submit" />
 			</form>
+				<div className={this.state.submitted ?  "submitted-text" : ''}>{this.state.submitted && <>Submitted!</>}<br></br></div>
+			</>
 		);
 	}
 }

--- a/src/Common.js
+++ b/src/Common.js
@@ -33,10 +33,10 @@ export class TextBox extends React.Component {
 	render() {
 		return (
 			<>
-			<form onSubmit={this.handleSubmit}>
-				<input type="text" value={this.state.value} onChange={this.handleChange} />
+				<form onSubmit={this.handleSubmit}>
+					<input type="text" value={this.state.value} onChange={this.handleChange} />
 					<input disabled={this.state.value.length===0} type="submit" value="Submit" />
-			</form>
+				</form>
 				<div className={this.state.submitted ?  "submitted-text" : ''}>{this.state.submitted && <>Submitted!</>}<br></br></div>
 			</>
 		);


### PR DESCRIPTION
I'm not really sure why the App.css decided that this was a huge change, maybe something to do with line endings?

Essentially the actual change is just the submitted-text bit, which does a small animated 'Submitted' message, basically to indicate to the user that something was submitted (which is more important when the rant content is hidden, since otherwise it's not clear that the message was sent)